### PR TITLE
Fixed Git clone link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ There are two methods for getting started with this repo.
 Checkout this repo, install depdencies, then start the gulp process with the following:
 
 ```
-	> git clone git@github.com:StephenGrider/ReactStarter.git
+	> git clone https://github.com/StephenGrider/ReactStarter.git
 	> cd ReactStarter
 	> npm install
 	> gulp


### PR DESCRIPTION
There were questions in the video comments as well, but I updated the Git link so cloning works.
