### PR TITLE
Symbol ^ missing from gulp-server-livereload. causing failure in npm …

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "gulp-concat": "^2.5.2",
     "gulp-react": "^3.0.1",
     "gulp-sass": "^2.0.1",
-    "gulp-server-livereload": "1.3.0",
+    "gulp-server-livereload": "^1.3.0",
     "gulp-util": "^3.0.4",
     "gulp-watch": "^4.2.4",
     "node-notifier": "^4.2.1",


### PR DESCRIPTION
…install

Since the version number was not having ^ symbol npm install would eventually break while installing gulp dependencies.
